### PR TITLE
Supports GitHub Enterprise Server environment

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -895,6 +895,7 @@ const core = __importStar(__nccwpck_require__(42186));
 const plugin_throttling_1 = __nccwpck_require__(9968);
 octokit_1.Octokit.plugin(plugin_throttling_1.throttling);
 exports.octokit = new octokit_1.Octokit({
+    baseUrl: process.env['GITHUB_API_URL'] || 'https://api.github.com',
     auth: core.getInput("GITHUB_TOKEN") || process.env.GITHUB_TOKEN,
     throttle: {
         onSecondaryRateLimit: (_, options) => {

--- a/src/octokit/octokit.ts
+++ b/src/octokit/octokit.ts
@@ -5,6 +5,7 @@ import { throttling } from "@octokit/plugin-throttling";
 Octokit.plugin(throttling);
 
 export const octokit = new Octokit({
+  baseUrl: process.env['GITHUB_API_URL'] || 'https://api.github.com',
   auth: core.getInput("GITHUB_TOKEN") || process.env.GITHUB_TOKEN,
   throttle: {
     onSecondaryRateLimit: (_, options) => {


### PR DESCRIPTION
## Description

Getting baseURL of Octokit from [environment variables](https://docs.github.com/en/actions/learn-github-actions/variables) to support [GitHub Enterprise Server](https://docs.github.com/en/enterprise-server@3.9/admin/overview/about-github-enterprise-server)

## Related Issue(s)
Nothing

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## How Has This Been Tested?

I've confirmed that this change is working with both of Github.com and GitHub Enterprise Server.

I'm sharing the result of GitHub.com as below.
https://github.com/h-r-k-matsumoto/lens-extension-menu/actions/runs/7237147422

But due to a company policies I work at, I'm afraid that I can't share a result of GitHub Enterprise Server.

## Checklist:
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [ ] I have updated the documentation accordingly.

## Additional Information

With GitHub Enterprise Server, the variables of `GITHUB_API_URL` is set automatically.
So I think it's okay not to update documentation.

And I've confirmed that current test cases are all passed.

- https://docs.github.com/en/actions/learn-github-actions/variables
- https://docs.github.com/en/enterprise-server@3.9/admin/overview/about-github-enterprise-server
- https://github.com/octokit/action.js/blob/main/src/index.ts#L56
