### PR TITLE
Feature: PR Size to Time dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pull-request-analytics-action",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Generates detailed PR analytics reports within GitHub, focusing on review efficiency and team performance.",
   "main": "build/index.js",
   "scripts": {

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -78,6 +78,29 @@ export type Collection = {
   discussions?: Discussion;
   discussionsTypes?: DiscussionType;
   prSizes?: string[];
+  sizes?: Record<
+    string,
+    {
+      timeToApprove: number[];
+      timeToReview: number[];
+      timeToMerge: number[];
+      percentile: {
+        timeToApprove?: number;
+        timeToReview?: number;
+        timeToMerge?: number;
+      };
+      average: {
+        timeToApprove?: number;
+        timeToReview?: number;
+        timeToMerge?: number;
+      };
+      median: {
+        timeToApprove?: number;
+        timeToReview?: number;
+        timeToMerge?: number;
+      };
+    }
+  >;
   reviewsConductedSize?: PullRequestSize[];
   pullRequestsInfo?: PullRequestTimelineInfo[];
 };

--- a/src/converters/utils/preparePullRequestStats.ts
+++ b/src/converters/utils/preparePullRequestStats.ts
@@ -34,6 +34,30 @@ export const preparePullRequestStats = (collection: Collection) => {
       collection.timeToMerge?.map((el) => el / 60),
       mergeIntervals
     ),
+    sizes: Object.entries(collection?.sizes || {}).reduce(
+      (acc, el) => ({
+        ...acc,
+        [el[0]]: {
+          ...acc[el[0]],
+          percentile: {
+            timeToReview: calcPercentileValue(acc[el[0]]?.timeToReview),
+            timeToApprove: calcPercentileValue(acc[el[0]]?.timeToApprove),
+            timeToMerge: calcPercentileValue(acc[el[0]]?.timeToMerge),
+          },
+          median: {
+            timeToReview: calcMedianValue(acc[el[0]]?.timeToReview),
+            timeToApprove: calcMedianValue(acc[el[0]]?.timeToApprove),
+            timeToMerge: calcMedianValue(acc[el[0]]?.timeToMerge),
+          },
+          average: {
+            timeToReview: calcAverageValue(acc[el[0]]?.timeToReview),
+            timeToApprove: calcAverageValue(acc[el[0]]?.timeToApprove),
+            timeToMerge: calcAverageValue(acc[el[0]]?.timeToMerge),
+          },
+        },
+      }),
+      collection?.sizes || {}
+    ),
     median: {
       timeToReview: calcMedianValue(collection.timeToReview),
       timeToApprove: calcMedianValue(collection.timeToApprove),

--- a/src/converters/utils/preparePullRequestTimeline.ts
+++ b/src/converters/utils/preparePullRequestTimeline.ts
@@ -1,7 +1,11 @@
 import { getMultipleValuesInput, getValueAsIs } from "../../common/utils";
 import { makeComplexRequest } from "../../requests";
 import { Collection } from "../types";
-import { calcDraftTime, getApproveTime } from "./calculations";
+import {
+  calcDraftTime,
+  getApproveTime,
+  getPullRequestSize,
+} from "./calculations";
 import { calcDifferenceInMinutes } from "./calculations/calcDifferenceInMinutes";
 
 export const preparePullRequestTimeline = (
@@ -89,21 +93,88 @@ export const preparePullRequestTimeline = (
 
   return {
     ...collection,
-    timeToReview: typeof timeToReview === 'number'
-      ? [...(collection?.timeToReview || []), timeToReview]
-      : collection.timeToReview,
-    timeToApprove: typeof timeToApprove === 'number'
-      ? [...(collection?.timeToApprove || []), timeToApprove]
-      : collection.timeToApprove,
-    timeToMerge: typeof timeToMerge === 'number'
-      ? [...(collection?.timeToMerge || []), timeToMerge]
-      : collection.timeToMerge,
-    timeToReviewRequest: typeof timeToReviewRequest === 'number'
-      ? [...(collection?.timeToReviewRequest || []), timeToReviewRequest]
-      : collection.timeToReviewRequest,
-    timeInDraft: typeof timeInDraft === 'number'
-      ? [...(collection?.timeInDraft || []), timeInDraft]
-      : collection.timeInDraft,
+    timeToReview:
+      typeof timeToReview === "number"
+        ? [...(collection?.timeToReview || []), timeToReview]
+        : collection.timeToReview,
+    timeToApprove:
+      typeof timeToApprove === "number"
+        ? [...(collection?.timeToApprove || []), timeToApprove]
+        : collection.timeToApprove,
+    timeToMerge:
+      typeof timeToMerge === "number"
+        ? [...(collection?.timeToMerge || []), timeToMerge]
+        : collection.timeToMerge,
+    timeToReviewRequest:
+      typeof timeToReviewRequest === "number"
+        ? [...(collection?.timeToReviewRequest || []), timeToReviewRequest]
+        : collection.timeToReviewRequest,
+    timeInDraft:
+      typeof timeInDraft === "number"
+        ? [...(collection?.timeInDraft || []), timeInDraft]
+        : collection.timeInDraft,
+    sizes: {
+      ...(collection.sizes || {}),
+      [getPullRequestSize(
+        pullRequestInfo?.additions,
+        pullRequestInfo?.deletions
+      )]: {
+        ...(collection.sizes?.[
+          getPullRequestSize(
+            pullRequestInfo?.additions,
+            pullRequestInfo?.deletions
+          )
+        ] || {}),
+        timeToApprove: timeToApprove
+          ? [
+              ...(collection?.sizes?.[
+                getPullRequestSize(
+                  pullRequestInfo?.additions,
+                  pullRequestInfo?.deletions
+                )
+              ]?.timeToApprove || []),
+              timeToApprove,
+            ]
+          : collection?.sizes?.[
+              getPullRequestSize(
+                pullRequestInfo?.additions,
+                pullRequestInfo?.deletions
+              )
+            ]?.timeToApprove,
+        timeToReview: timeToReview
+          ? [
+              ...(collection?.sizes?.[
+                getPullRequestSize(
+                  pullRequestInfo?.additions,
+                  pullRequestInfo?.deletions
+                )
+              ]?.timeToReview || []),
+              timeToReview,
+            ]
+          : collection?.sizes?.[
+              getPullRequestSize(
+                pullRequestInfo?.additions,
+                pullRequestInfo?.deletions
+              )
+            ]?.timeToReview,
+        timeToMerge: timeToMerge
+          ? [
+              ...(collection?.sizes?.[
+                getPullRequestSize(
+                  pullRequestInfo?.additions,
+                  pullRequestInfo?.deletions
+                )
+              ]?.timeToMerge || []),
+              timeToMerge,
+            ]
+          : collection?.sizes?.[
+              getPullRequestSize(
+                pullRequestInfo?.additions,
+                pullRequestInfo?.deletions
+              )
+            ]?.timeToMerge,
+      },
+    },
     pullRequestsInfo: [
       ...(collection?.pullRequestsInfo || []),
       {

--- a/src/view/utils/createSizeDependencyXYChart.ts
+++ b/src/view/utils/createSizeDependencyXYChart.ts
@@ -1,0 +1,75 @@
+import { Collection } from "../../converters/types";
+import { StatsType } from "./types";
+import { getValueAsIs } from "../../common/utils";
+import { createXYChart } from "./common/createXYChart";
+const sizes = ["xs", "s", "m", "l", "xl"];
+
+export const createSizeDependencyXYChart = (
+  data: Record<string, Record<string, Collection>>,
+  type: StatsType,
+  user: string
+) => {
+  return createXYChart({
+    title: `Pull request's size dependency timeline(${
+      type === "percentile" ? parseInt(getValueAsIs("PERCENTILE")) : ""
+    }${type === "percentile" ? "th " : ""}${type}) ${user}`,
+    xAxis: sizes,
+    yAxis: {
+      min: 0,
+      max: Math.ceil(
+        Math.max(
+          ...sizes.map((size) =>
+            Math.max(
+              ...["timeToReview", "timeToApprove", "timeToMerge"].map(
+                (key) =>
+                  data[user]?.total?.sizes?.[size]?.[type]?.[
+                    key as "timeToReview" | "timeToApprove" | "timeToMerge"
+                  ] || 0
+              )
+            )
+          ),
+          1
+        ) / 60
+      ),
+      title: "hours",
+    },
+    lines: [
+      {
+        color: "gold",
+        name: "Time\\ To\\ Review",
+        values: sizes.map(
+          (size) =>
+            Math.round(
+              ((data[user]?.total?.sizes?.[size]?.[type]?.timeToReview || 0) /
+                60) *
+                100
+            ) / 100
+        ),
+      },
+      {
+        color: "chartreuse",
+        name: "Time\\ To\\ Approve",
+        values: sizes.map(
+          (size) =>
+            Math.round(
+              ((data[user]?.total?.sizes?.[size]?.[type]?.timeToApprove || 0) /
+                60) *
+                100
+            ) / 100
+        ),
+      },
+      {
+        color: "blueviolet",
+        name: "Time\\ To\\ Merge",
+        values: sizes.map(
+          (size) =>
+            Math.round(
+              ((data[user]?.total?.sizes?.[size]?.[type]?.timeToMerge || 0) /
+                60) *
+                100
+            ) / 100
+        ),
+      },
+    ],
+  });
+};

--- a/src/view/utils/createTimelineMonthComparisonChart.ts
+++ b/src/view/utils/createTimelineMonthComparisonChart.ts
@@ -2,6 +2,7 @@ import { createReferences } from ".";
 import { getMultipleValuesInput } from "../../common/utils";
 import { Collection } from "../../converters/types";
 import { createContributionMonthsXYChart } from "./createContributionMonthXYChart";
+import { createSizeDependencyXYChart } from "./createSizeDependencyXYChart";
 import { createTimelineMonthsXYChart } from "./createTimelineMonthXYChart";
 import { StatsType } from "./types";
 
@@ -24,12 +25,15 @@ export const createTimelineMonthComparisonChart = (
           ).length > 2
       )
       .map((type) =>
-        createTimelineMonthsXYChart(
-          data,
-          type as StatsType,
-          dates.filter((date) => date !== "total"),
-          user
-        )
+        [
+          createTimelineMonthsXYChart(
+            data,
+            type as StatsType,
+            dates.filter((date) => date !== "total"),
+            user
+          ),
+          createSizeDependencyXYChart(data, type as StatsType, user),
+        ].join("\n")
       )
       .join("\n");
     const contribution =


### PR DESCRIPTION
# Pull Request

## Description
Added XY graph to show Time/PR size dependency 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/AlexSim93/pull-request-analytics-action/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] My changes generate no new warnings.
- [x] I have updated the documentation accordingly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new chart feature to visualize pull request size dependencies, providing insights into review, approval, and merge times.
	- Enhanced statistical analysis capabilities for pull requests with new metrics for time to review, approve, and merge.

- **Bug Fixes**
	- Improved data structure for pull request timelines, allowing for a more detailed breakdown of metrics by size.

- **Documentation**
	- Updated version number to 4.2.0 in the package.json file.

- **Chores**
	- Refined existing functions to incorporate new metrics and improve overall data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->